### PR TITLE
Fix markdown warnings and use more inclusive text.

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -12,21 +12,23 @@ A clear and concise description of what the bug is.
 
 **To Reproduce**
 Steps to reproduce the behavior:
+
 1. Go to '...'
-2. Click on '....'
+2. Select '....'
 3. Scroll down to '....'
-4. See error
+4. Note the error
 
 **Expected behavior**
 A clear and concise description of what you expected to happen.
 
 **Screenshots or CLI Output**
-If applicable, add screenshots or the CLI ouput to help explain your problem.
+If applicable, add screenshots or the CLI output to help explain your problem.
 
 **Desktop (please complete the following information):**
+
 - OS: [e.g. macOS]
 - OS Version: [e.g. 13.0]
-- Browser if applicable [e.g. Chrome, Firefox]
+- Browser if applicable: [e.g. Chrome, Firefox]
 - Browser Version: [e.g. 106]
 
 **Additional context**

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,11 +4,11 @@
 
 Mondoo values responsible disclosure to protect the security and privacy of all our users. We actively encourage respectful and non-disruptive testing and reporting of detected vulnerabilities, within the following guidelines:
 
- - DO submit reports as soon as you are aware of an issue
- - DO allow time to assess and respond to the submission 
- - DO respect the availability, confidentiality and privacy of our services, users and any 3rd party systems
- - DO NOT attack or otherwise interfere with any account you are not the owner of
- - DO NOT violate any applicable laws or regulations
- - DO NOT disclose issues publicly before we've had time to assess and respond appropriately
+- DO submit reports as soon as you are aware of an issue
+- DO allow time to assess and respond to the submission 
+- DO respect the availability, confidentiality and privacy of our services, users and any 3rd party systems
+- DO NOT attack or otherwise interfere with any account you are not the owner of
+- DO NOT violate any applicable laws or regulations
+- DO NOT disclose issues publicly before we've had time to assess and respond appropriately
 
 Please submit individual reports to security@mondoo.com including a full description of the finding, how to reproduce the behavior and any supporting information.  Applicable submissions will be directed to our Bug Bounty Program.


### PR DESCRIPTION
- Select vs. Click for screenreaders
- Fix a typo
- Fix markdown warnings

Signed-off-by: Tim Smith <tsmith84@gmail.com>