### PR TITLE
Setup dependabot to keep the GitHub action up to date

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: daily


### PR DESCRIPTION
This will let us roll out the latest mondoo updates when they ship

Signed-off-by: Tim Smith <tsmith84@gmail.com>