### PR TITLE
chore: pin GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/github.yaml
+++ b/.github/workflows/github.yaml
@@ -8,14 +8,14 @@ jobs:
   mondoo-scan:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Generate token
         id: generate_token
-        uses: tibdex/github-app-token@v2
+        uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a # v2.1.0
         with:
           app_id: ${{ secrets.APP_ID }}
           private_key: ${{ secrets.APP_PRIVATE_KEY }}
-      - uses: mondoohq/actions/github-org@v13.1.0
+      - uses: mondoohq/actions/github-org@20caefcb2d1258d051149913cde321a698b1fdb9 # v13.1.0
         env:
           MONDOO_CONFIG_BASE64: ${{ secrets.MONDOO_SERVICE_ACCOUNT }}
           GITHUB_TOKEN: ${{ steps.generate_token.outputs.token }}


### PR DESCRIPTION
Pin all GitHub Actions to full commit SHAs instead of mutable tags for supply chain security.