### PR TITLE
feat(actions): add mint-otlp-token composite action

### DIFF
--- a/actions/mint-otlp-token/README.md
+++ b/actions/mint-otlp-token/README.md
@@ -1,0 +1,105 @@
+# mint-otlp-token
+
+Mints a GitHub Actions OIDC JWT for `otlp.mondoo.love` and exposes it as env
+vars to subsequent steps. After this action runs, any OTel SDK / `otel-cli` /
+`curl` command in the same job can push traces, metrics, and logs to the
+Mondoo LGTM stack with no shared secret.
+
+## Quick start
+
+```yaml
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write   # required — without this the mint fails
+      contents: read
+    steps:
+      - uses: mondoohq/.github/actions/mint-otlp-token@main
+
+      # OTEL_EXPORTER_OTLP_ENDPOINT and OTEL_EXPORTER_OTLP_HEADERS
+      # are now in $GITHUB_ENV; SDKs auto-discover them.
+      - run: ./scripts/run-my-instrumented-app
+```
+
+## With otel-cli (wrap arbitrary commands in spans)
+
+```yaml
+- uses: mondoohq/.github/actions/mint-otlp-token@main
+
+- name: Install otel-cli
+  run: |
+    curl -fsSL https://github.com/equinix-labs/otel-cli/releases/download/v0.4.5/otel-cli_0.4.5_linux_amd64.tar.gz \
+      | sudo tar -xz -C /usr/local/bin otel-cli
+
+- env:
+    OTEL_SERVICE_NAME: my-build
+  run: otel-cli exec --name "build" --kind client -- make build
+
+- env:
+    OTEL_SERVICE_NAME: my-build
+  run: otel-cli exec --name "test"  --kind client -- make test
+```
+
+Result: one span per wrapped step in Grafana → Explore → Tempo,
+queryable by `service.name = my-build`.
+
+## With curl (manual metric push)
+
+```yaml
+- uses: mondoohq/.github/actions/mint-otlp-token@main
+
+- name: Push a counter
+  run: |
+    NOW_NS=$(date +%s%N)
+    curl --fail-with-body -sS -X POST "${OTEL_EXPORTER_OTLP_ENDPOINT}/v1/metrics" \
+      -H "Authorization: Bearer ${OTLP_JWT}" \
+      -H 'Content-Type: application/json' \
+      --data-binary "$(jq -n --arg ts "$NOW_NS" --arg svc "${{ github.workflow }}" '
+        {resourceMetrics:[{
+          resource:{attributes:[{key:"service.name",value:{stringValue:$svc}}]},
+          scopeMetrics:[{metrics:[{
+            name:"my_deploys",
+            sum:{aggregationTemporality:2,isMonotonic:true,
+                 dataPoints:[{asInt:"1",timeUnixNano:$ts,startTimeUnixNano:$ts}]}
+          }]}]
+        }]}')"
+```
+
+## Inputs
+
+| Input | Default | When to override |
+|---|---|---|
+| `audience` | `otlp.mondoo.love` | Only if the collector audience is renamed |
+| `endpoint` | `https://otlp.mondoo.love` | Local testing against a different collector |
+
+## What it sets in `$GITHUB_ENV`
+
+| Var | Value |
+|---|---|
+| `OTLP_JWT` | The raw signed JWT (masked) |
+| `OTEL_EXPORTER_OTLP_ENDPOINT` | `https://otlp.mondoo.love` |
+| `OTEL_EXPORTER_OTLP_HEADERS` | `Authorization=Bearer <jwt>` |
+
+## Caveats
+
+- **Tokens are short-lived (~5 min).** Mint per job. If a job's push happens
+  more than 5 minutes after the mint, re-invoke this action before pushing.
+  In practice rarely a concern — most CI work fits in one token's lifetime.
+- **Only `mondoohq/*` repos can push.** Caddy enforces
+  `repository_owner=mondoohq` at the proxy layer; tokens from other orgs
+  return `HTTP 403: Forbidden: repository_owner not in allowlist`.
+- **`permissions: id-token: write` is mandatory.** Without it the runner
+  doesn't inject the `ACTIONS_ID_TOKEN_REQUEST_*` env vars and the mint
+  fails with a clear error message. `permissions:` defaults to
+  `contents: read` only — easy to miss.
+- **Works on both `ubuntu-latest` and the mondoohq self-hosted runners.**
+  The OIDC issuer is the same in both.
+
+## Where the telemetry lands
+
+| Signal | Backend | How to query |
+|---|---|---|
+| Traces | Tempo | Grafana → Explore → Tempo → `service.name = ...` |
+| Metrics | VictoriaMetrics | `<metric>_total{service_name="..."}` (counter convention) |
+| Logs | VictoriaLogs | `{service_name="..."}` |

--- a/actions/mint-otlp-token/action.yml
+++ b/actions/mint-otlp-token/action.yml
@@ -1,0 +1,56 @@
+name: Mint OTLP token
+description: >
+  Mint a GitHub Actions OIDC JWT for otlp.mondoo.love and expose it (along
+  with the standard OTEL_EXPORTER_OTLP_* env vars) to subsequent steps in
+  the same job. Any OTel SDK or otel-cli command after this step will
+  auto-pick-up the endpoint and bearer.
+
+inputs:
+  audience:
+    description: OIDC token audience. Must match the collector's audience_whitelist.
+    required: false
+    default: otlp.mondoo.love
+  endpoint:
+    description: OTLP endpoint URL (no trailing slash).
+    required: false
+    default: https://otlp.mondoo.love
+
+runs:
+  using: composite
+  steps:
+    - shell: bash
+      env:
+        AUDIENCE: ${{ inputs.audience }}
+        ENDPOINT: ${{ inputs.endpoint }}
+      run: |
+        set -euo pipefail
+
+        if [ -z "${ACTIONS_ID_TOKEN_REQUEST_URL:-}" ]; then
+          echo "::error::ACTIONS_ID_TOKEN_REQUEST_URL not set — did you forget 'permissions: id-token: write' on the job?"
+          exit 1
+        fi
+
+        jwt=$(curl --fail-with-body -sS \
+          -H "Authorization: Bearer ${ACTIONS_ID_TOKEN_REQUEST_TOKEN}" \
+          "${ACTIONS_ID_TOKEN_REQUEST_URL}&audience=${AUDIENCE}" \
+          | jq -r '.value')
+
+        # jq -r '.value' on a missing field prints the literal string "null".
+        # Catch that, empty results, and tokens that don't look like a JWT.
+        if [ -z "$jwt" ] || [ "$jwt" = "null" ] || [[ "$jwt" != *.*.* ]]; then
+          echo "::error::OIDC token mint returned empty / null / malformed token"
+          exit 1
+        fi
+
+        # Mask BEFORE writing to $GITHUB_ENV so the value never lands in
+        # the runner's exported-env log line for the next step.
+        echo "::add-mask::$jwt"
+
+        # Set both OTEL_* and the raw OTLP_JWT so callers can use either
+        # OTel SDKs (which auto-discover OTEL_EXPORTER_OTLP_*) or curl /
+        # otel-cli with the bare token.
+        {
+          echo "OTLP_JWT=$jwt"
+          echo "OTEL_EXPORTER_OTLP_ENDPOINT=${ENDPOINT}"
+          echo "OTEL_EXPORTER_OTLP_HEADERS=Authorization=Bearer ${jwt}"
+        } >> "$GITHUB_ENV"


### PR DESCRIPTION
Adds a reusable composite action at `actions/mint-otlp-token/` that mints a GitHub Actions OIDC JWT for `otlp.mondoo.love` and exposes it (plus the `OTEL_EXPORTER_OTLP_*` env vars) to subsequent steps in the same job. After this action runs, any OTel SDK / `otel-cli` / `curl` command in the job can push traces, metrics, and logs to the Mondoo LGTM stack with no shared secret.

## Usage from any `mondoohq/*` repo

```yaml
jobs:
  ci:
    runs-on: ubuntu-latest
    permissions:
      id-token: write
      contents: read
    steps:
      - uses: mondoohq/.github/actions/mint-otlp-token@main
      - run: ./instrumented-thing
```

## Why now

End-to-end OIDC auth on `otlp.mondoo.love` was just validated in mondoohq/private-runners#89 — the collector now accepts GitHub Actions JWTs validated by `caddy-jwt` (signature + iss + aud + `repository_owner=mondoohq`). This action is the standard adoption surface so individual repos don't each reimplement the mint-and-export dance.

## What the action does

1. Verifies `permissions: id-token: write` is set (clear error if not).
2. Mints a JWT from the runner with `audience=otlp.mondoo.love`.
3. Guards against `null`/empty/malformed responses (the JWT shape check catches truncated tokens that would otherwise produce opaque 401s downstream).
4. `::add-mask::`s the value before any `$GITHUB_ENV` write.
5. Exposes `OTLP_JWT`, `OTEL_EXPORTER_OTLP_ENDPOINT`, `OTEL_EXPORTER_OTLP_HEADERS` to the rest of the job.

## Files

- `actions/mint-otlp-token/action.yml` — the action itself
- `actions/mint-otlp-token/README.md` — three usage patterns (SDK auto-discovery, `otel-cli`, raw `curl`), inputs/outputs table, four caveats, query examples

No changes outside `actions/mint-otlp-token/`.